### PR TITLE
follow whitespace rule of strings.TrimSpace

### DIFF
--- a/circuitcompiler/lexer.go
+++ b/circuitcompiler/lexer.go
@@ -32,7 +32,7 @@ const (
 var eof = rune(0)
 
 func isWhitespace(ch rune) bool {
-	return ch == ' ' || ch == '\t' || ch == '\n'
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\v' || ch == '\f'
 }
 
 func isLetter(ch rune) bool {


### PR DESCRIPTION
it's related to #13 compilation error on Windows. 

Root cause:
Didn't treat `\r` as part of white space in `isWhitespace` of `lexer.go`

Solution:
Follow golang function `strings.TrimSpace`, filter out `\r`, `\v`, `\f`